### PR TITLE
feat(10): My Tickets — full-stack list, search, filter, sort, pagination

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { checkSystem, type Category } from "./api.js";
 import Header from "./components/Header";
 import { RequesterProvider } from "./context/RequesterContext";
 import { useRequester } from "./hooks/useRequester";
+import MyTickets from "./pages/MyTickets";
 import RequesterSelection from "./pages/RequesterSelection.js";
 import CreateTicket from "./pages/CreateTicket";
 
@@ -109,15 +110,6 @@ function SystemStatusHome() {
   );
 }
 
-function ComingSoon({ title }: { title: string }) {
-  return (
-    <div className="text-center p-5">
-      <h2 className="fw-bold text-brand">{title}</h2>
-      <p className="text-secondary">This screen isn't implemented yet.</p>
-    </div>
-  );
-}
-
 // ป้องกัน Route: เด้งกลับไปหน้าเลือก Requester ทันทีถ้ายังไม่มี (FR-03)
 function ProtectedRoute({ children }: { children: React.JSX.Element }) {
   const { requester, isLoading } = useRequester();
@@ -142,7 +134,7 @@ function App() {
         
         <Route path="/my-tickets" element={
           <ProtectedRoute>
-            <ComingSoon title="My Tickets" />
+            <MyTickets />
           </ProtectedRoute>
         } />
         <Route path="/create-ticket" element={

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -17,8 +17,15 @@ export interface Requester {
   isActive: boolean;
 }
 
+export interface SystemStatus {
+  online: boolean;
+  categories: Category[];
+}
+
 export type Priority = "LOW" | "MEDIUM" | "HIGH" | "URGENT";
 export type Status = "PENDING" | "IN_PROGRESS" | "RESOLVED" | "CLOSED";
+export type SortField = "createdAt" | "priority";
+export type SortOrder = "asc" | "desc";
 
 export interface Ticket {
   id: number;
@@ -42,9 +49,40 @@ export interface CreateTicketPayload {
   priority: Priority;
 }
 
-export interface SystemStatus {
-  online: boolean;
-  categories: Category[];
+export interface TicketSummary {
+  id: number;
+  ticketNo: string;
+  title: string;
+  description: string;
+  priority: Priority;
+  status: Status;
+  createdAt: string;
+  category: Category;
+  system: RelatedSystem;
+}
+
+export interface Pagination {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface TicketsResponse {
+  tickets: TicketSummary[];
+  pagination: Pagination;
+}
+
+export interface TicketQuery {
+  search?: string;
+  categoryId?: number;
+  systemId?: number;
+  status?: Status;
+  priority?: Priority;
+  sort?: SortField;
+  order?: SortOrder;
+  page?: number;
+  limit?: number;
 }
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -59,8 +97,13 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export async function checkSystem(): Promise<SystemStatus> {
-  const healthData = await request<{ status: string }>("/api/health");
-  const categories = await getCategories().catch(() => []);
+  const res = await fetch(`${API_URL}/api/health`);
+  if (!res.ok) {
+    throw new Error(`Health check failed with status: ${res.status}`);
+  }
+  const healthData = await res.json();
+  const catRes = await fetch(`${API_URL}/api/categories`);
+  const categories = catRes.ok ? await catRes.json() : [];
   return {
     online: healthData.status === "ok",
     categories,
@@ -86,5 +129,26 @@ export function createTicket(
       "x-requester-id": String(requesterId),
     },
     body: JSON.stringify(payload),
+  });
+}
+
+function buildQueryString(query: TicketQuery): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === "") continue;
+    params.set(key, String(value));
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export function getTickets(
+  query: TicketQuery,
+  requesterId: number
+): Promise<TicketsResponse> {
+  return request<TicketsResponse>(`/api/tickets${buildQueryString(query)}`, {
+    headers: {
+      "x-requester-id": String(requesterId),
+    },
   });
 }

--- a/client/src/pages/MyTickets.tsx
+++ b/client/src/pages/MyTickets.tsx
@@ -1,0 +1,507 @@
+import { useState, useEffect } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Search,
+  FilterX,
+} from "lucide-react";
+import {
+  getCategories,
+  getSystems,
+  getTickets,
+  type Category,
+  type RelatedSystem,
+  type Status,
+  type Priority,
+  type SortField,
+  type SortOrder,
+  type TicketQuery,
+  type TicketSummary,
+  type Pagination,
+} from "../api";
+import { useRequester } from "../hooks/useRequester";
+import Badge from "../components/Badge";
+import Button from "../components/Button";
+import TextInput from "../components/TextInput";
+
+const DEFAULT_QUERY: TicketQuery = {
+  sort: "createdAt",
+  order: "desc",
+};
+
+const STATUSES: Status[] = ["PENDING", "IN_PROGRESS", "RESOLVED", "CLOSED"];
+const PRIORITIES: Priority[] = ["LOW", "MEDIUM", "HIGH", "URGENT"];
+const PAGE_SIZES = [10, 20, 50];
+
+const STATUS_COLOR: Record<Status, "gray" | "blue" | "green"> = {
+  PENDING: "gray",
+  IN_PROGRESS: "blue",
+  RESOLVED: "green",
+  CLOSED: "gray",
+};
+
+const PRIORITY_COLOR: Record<Priority, "gray" | "yellow" | "red"> = {
+  LOW: "gray",
+  MEDIUM: "yellow",
+  HIGH: "red",
+  URGENT: "red",
+};
+
+function formatDate(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleDateString();
+}
+
+function PriorityBadge({ priority }: { priority: Priority }) {
+  return <Badge color={PRIORITY_COLOR[priority]}>{priority}</Badge>;
+}
+
+function StatusBadge({ status }: { status: Status }) {
+  return <Badge color={STATUS_COLOR[status]}>{status}</Badge>;
+}
+
+function EmptyState({ onReset, hasActiveFilters }: { onReset: () => void; hasActiveFilters: boolean }) {
+  return (
+    <div data-testid={hasActiveFilters ? "no-results" : "empty-state"} className="text-center py-5">
+      <FilterX size={40} className="text-secondary mb-3" />
+      <h5 className="fw-bold text-dark mb-1">
+        {hasActiveFilters ? "No matching tickets" : "No tickets yet"}
+      </h5>
+      <p className="text-secondary small mb-0">
+        {hasActiveFilters
+          ? "No tickets match your current search or filters."
+          : "Tickets you create will appear here."}
+      </p>
+      {hasActiveFilters && (
+        <Button variant="secondary" className="mt-3" onClick={onReset}>
+          Clear Filters
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div data-testid="tickets-error" role="alert" className="alert alert-danger d-flex justify-content-between align-items-center py-3">
+      <span>{message}</span>
+      <Button variant="secondary" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+function DesktopTable({ tickets }: { tickets: TicketSummary[] }) {
+  return (
+    <div className="d-none d-md-block overflow-auto">
+      <table className="table table-hover align-middle mb-0" data-testid="tickets-table">
+        <thead className="table-light">
+          <tr>
+            <th scope="col">Ticket No</th>
+            <th scope="col">Title</th>
+            <th scope="col">Category</th>
+            <th scope="col">Priority</th>
+            <th scope="col">Status</th>
+            <th scope="col">Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tickets.map((t) => (
+            <tr key={t.id} data-testid="ticket-row">
+              <td className="fw-semibold text-dark">{t.ticketNo}</td>
+              <td className="text-dark">{t.title}</td>
+              <td>{t.category.name}</td>
+              <td>
+                <PriorityBadge priority={t.priority} />
+              </td>
+              <td>
+                <StatusBadge status={t.status} />
+              </td>
+              <td className="text-secondary small">{formatDate(t.createdAt)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MobileCards({ tickets }: { tickets: TicketSummary[] }) {
+  return (
+    <div className="d-md-none d-flex flex-column gap-3">
+      {tickets.map((t) => (
+        <div
+          key={t.id}
+          data-testid="ticket-card"
+          className="card border-0 shadow-sm rounded-3 p-3"
+        >
+          <div className="d-flex justify-content-between align-items-start gap-2">
+            <div>
+              <div className="fw-semibold text-dark small">{t.ticketNo}</div>
+              <div className="fw-bold text-dark">{t.title}</div>
+              <div className="text-secondary small">{t.category.name}</div>
+            </div>
+            <div className="d-flex flex-column gap-1 align-items-end">
+              <PriorityBadge priority={t.priority} />
+              <StatusBadge status={t.status} />
+            </div>
+          </div>
+          <div className="mt-2 text-secondary small">Created {formatDate(t.createdAt)}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PaginationBar({
+  pagination,
+  onPageChange,
+  onLimitChange,
+}: {
+  pagination: Pagination;
+  onPageChange: (page: number) => void;
+  onLimitChange: (limit: number) => void;
+}) {
+  const { page, limit, totalPages } = pagination;
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  return (
+    <div className="d-flex flex-wrap justify-content-center align-items-center gap-3 my-4">
+      <button
+        type="button"
+        className="btn btn-outline-secondary btn-sm"
+        aria-label="Previous page"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+      >
+        <ChevronLeft size={16} />
+      </button>
+
+      <ul className="pagination mb-0">
+        {pages.map((p) => (
+          <li key={p} className={`page-item ${p === page ? "active" : ""}`}>
+            <button
+              type="button"
+              className="page-link"
+              data-testid="page-number"
+              onClick={() => onPageChange(p)}
+            >
+              {p}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <button
+        type="button"
+        className="btn btn-outline-secondary btn-sm"
+        aria-label="Next page"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+      >
+        <ChevronRight size={16} />
+      </button>
+
+      <select
+        className="form-select form-select-sm"
+        style={{ width: "auto" }}
+        aria-label="Tickets per page"
+        data-testid="page-size"
+        value={limit}
+        onChange={(e) => onLimitChange(Number(e.target.value))}
+      >
+        {PAGE_SIZES.map((n) => (
+          <option key={n} value={n}>
+            {n} per page
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export default function MyTickets() {
+  const { requester } = useRequester();
+  const requesterId = requester?.id;
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [systems, setSystems] = useState<RelatedSystem[]>([]);
+
+  const [draftSearch, setDraftSearch] = useState("");
+  const [appliedQuery, setAppliedQuery] = useState<TicketQuery>(DEFAULT_QUERY);
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(10);
+
+  const [tickets, setTickets] = useState<TicketSummary[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadOptions = async () => {
+      try {
+        const [cats, sys] = await Promise.all([getCategories(), getSystems()]);
+        if (!cancelled) {
+          setCategories(cats);
+          setSystems(sys);
+        }
+      } catch {
+        // Filter dropdowns stay empty; list still renders.
+      }
+    };
+
+    loadOptions();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (requesterId === undefined) return;
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      const query: TicketQuery = { ...appliedQuery, page, limit };
+      try {
+        const res = await getTickets(query, requesterId);
+        if (cancelled) return;
+        setTickets(res.tickets);
+        setPagination(res.pagination);
+      } catch (err) {
+        if (cancelled) return;
+        setTickets([]);
+        setPagination(null);
+        setError(err instanceof Error ? err.message : "Failed to load tickets.");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [requesterId, appliedQuery, page, limit, retryKey]);
+
+  const updateQuery = (patch: Partial<TicketQuery>) => {
+    setAppliedQuery((prev) => ({ ...prev, ...patch }));
+    setPage(1);
+  };
+
+  const handleSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    updateQuery({ search: draftSearch.trim() || undefined });
+  };
+
+  const handleClearFilters = () => {
+    setDraftSearch("");
+    setAppliedQuery(DEFAULT_QUERY);
+    setPage(1);
+  };
+
+  const handleSortChange = (draftSort: SortField) => {
+    let order: SortOrder;
+    if (appliedQuery.sort !== draftSort) {
+      order = "desc";
+    } else {
+      order = appliedQuery.order === "desc" ? "asc" : "desc";
+    }
+    updateQuery({ sort: draftSort, order });
+  };
+
+  const hasActiveFilters = Boolean(
+    appliedQuery.search ||
+      appliedQuery.categoryId ||
+      appliedQuery.systemId ||
+      appliedQuery.status ||
+      appliedQuery.priority
+  );
+
+  return (
+    <div className="container py-4" style={{ maxWidth: "1080px" }}>
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <div>
+          <h2 className="h4 fw-bold text-dark mb-0">My Tickets</h2>
+          <p className="text-secondary small mb-0">
+            {requester ? `Showing tickets for ${requester.name}` : "My tickets"}
+          </p>
+        </div>
+      </div>
+
+      <div className="card shadow-sm border-0 rounded-3 p-3 mb-3">
+        <form className="row g-2 align-items-end" onSubmit={handleSearchSubmit} noValidate>
+          <div className="col-12 col-md-4">
+            <label className="form-label fw-bold small text-dark" htmlFor="ticket-search">
+              Search
+            </label>
+            <TextInput
+              id="ticket-search"
+              data-testid="ticket-search"
+              value={draftSearch}
+              onChange={(e) => setDraftSearch(e.target.value)}
+              placeholder="Search title or description..."
+            />
+          </div>
+
+          <div className="col-6 col-md-2">
+            <label className="form-label fw-bold small text-dark" htmlFor="filter-category">
+              Category
+            </label>
+            <select
+              id="filter-category"
+              data-testid="filter-category"
+              className="form-select"
+              value={appliedQuery.categoryId ?? ""}
+              onChange={(e) =>
+                updateQuery({ categoryId: e.target.value ? Number(e.target.value) : undefined })
+              }
+            >
+              <option value="">All</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="col-6 col-md-2">
+            <label className="form-label fw-bold small text-dark" htmlFor="filter-system">
+              System
+            </label>
+            <select
+              id="filter-system"
+              data-testid="filter-system"
+              className="form-select"
+              value={appliedQuery.systemId ?? ""}
+              onChange={(e) =>
+                updateQuery({ systemId: e.target.value ? Number(e.target.value) : undefined })
+              }
+            >
+              <option value="">All</option>
+              {systems.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="col-6 col-md-2">
+            <label className="form-label fw-bold small text-dark" htmlFor="filter-status">
+              Status
+            </label>
+            <select
+              id="filter-status"
+              data-testid="filter-status"
+              className="form-select"
+              value={appliedQuery.status ?? ""}
+              onChange={(e) =>
+                updateQuery({ status: (e.target.value || undefined) as Status | undefined })
+              }
+            >
+              <option value="">All</option>
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="col-6 col-md-2">
+            <label className="form-label fw-bold small text-dark" htmlFor="filter-priority">
+              Priority
+            </label>
+            <select
+              id="filter-priority"
+              data-testid="filter-priority"
+              className="form-select"
+              value={appliedQuery.priority ?? ""}
+              onChange={(e) =>
+                updateQuery({ priority: (e.target.value || undefined) as Priority | undefined })
+              }
+            >
+              <option value="">All</option>
+              {PRIORITIES.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="col-12 col-md-12 d-flex gap-2 mt-2">
+            <Button type="submit" variant="secondary">
+              <Search size={16} className="me-1" />
+              Apply
+            </Button>
+            <Button variant="secondary" type="button" onClick={handleClearFilters}>
+              Clear
+            </Button>
+            <div className="d-flex align-items-center ms-auto gap-2">
+              <span className="small text-secondary">Sort</span>
+              <button
+                type="button"
+                className={`btn btn-sm ${appliedQuery.sort === "createdAt" ? "btn-brand text-white" : "btn-outline-secondary"}`}
+                data-testid="sort-createdAt"
+                onClick={() => handleSortChange("createdAt")}
+              >
+                Date {appliedQuery.sort === "createdAt" ? (appliedQuery.order === "asc" ? "↑" : "↓") : ""}
+              </button>
+              <button
+                type="button"
+                className={`btn btn-sm ${appliedQuery.sort === "priority" ? "btn-brand text-white" : "btn-outline-secondary"}`}
+                data-testid="sort-priority"
+                onClick={() => handleSortChange("priority")}
+              >
+                Priority {appliedQuery.sort === "priority" ? (appliedQuery.order === "asc" ? "↑" : "↓") : ""}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+
+      {error && (
+        <ErrorState
+          message={error}
+          onRetry={() => setRetryKey((k) => k + 1)}
+        />
+      )}
+
+      {isLoading && !error ? (
+        <div className="py-5 text-center text-secondary" data-testid="tickets-loading">
+          Loading tickets...
+        </div>
+      ) : !error && tickets.length === 0 ? (
+        <div className="card shadow-sm border-0 rounded-3">
+          <EmptyState onReset={handleClearFilters} hasActiveFilters={hasActiveFilters} />
+        </div>
+      ) : !error ? (
+        <>
+          <div className="card shadow-sm border-0 rounded-3 overflow-hidden">
+            <DesktopTable tickets={tickets} />
+            <MobileCards tickets={tickets} />
+          </div>
+          {pagination && (
+            <PaginationBar
+              pagination={pagination}
+              onPageChange={setPage}
+              onLimitChange={(next) => {
+                setLimit(next);
+                setPage(1);
+              }}
+            />
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent, cleanup } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import * as api from "../../src/api";
+import MyTickets from "../../src/pages/MyTickets";
+import { RequesterProvider } from "../../src/context/RequesterContext";
+
+vi.mock("lucide-react", () => ({
+  ChevronLeft: () => null,
+  ChevronRight: () => null,
+  Search: () => null,
+  FilterX: () => null,
+}));
+
+const CATEGORIES = [
+  { id: 1, name: "Account and Access" },
+  { id: 3, name: "Network" },
+];
+const SYSTEMS = [
+  { id: 1, name: "Email Client" },
+  { id: 3, name: "VPN Service" },
+];
+
+const TICKETS: api.TicketSummary[] = [
+  {
+    id: 1,
+    ticketNo: "TK-20260906-0001",
+    title: "VPN drops every 5 minutes",
+    description: "Cannot stay connected",
+    priority: "HIGH",
+    status: "PENDING",
+    createdAt: "2026-09-06T04:18:20.000Z",
+    category: { id: 3, name: "Network" },
+    system: { id: 3, name: "VPN Service" },
+  },
+  {
+    id: 2,
+    ticketNo: "TK-20260906-0002",
+    title: "Printer jams on third floor",
+    description: "Paper stuck",
+    priority: "LOW",
+    status: "IN_PROGRESS",
+    createdAt: "2026-09-05T09:10:00.000Z",
+    category: { id: 3, name: "Network" },
+    system: { id: 1, name: "Email Client" },
+  },
+];
+
+const PAGINATION: api.Pagination = { total: 25, page: 1, limit: 10, totalPages: 3 };
+
+const getTicketsMock = vi.fn();
+
+describe("MyTickets Component", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getTicketsMock.mockResolvedValue({ tickets: TICKETS, pagination: PAGINATION });
+    vi.spyOn(api, "getCategories").mockResolvedValue(CATEGORIES);
+    vi.spyOn(api, "getSystems").mockResolvedValue(SYSTEMS);
+    vi.spyOn(api, "getTickets").mockImplementation(getTicketsMock);
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  const renderPage = () => {
+    window.localStorage.setItem(
+      "toktickit.selectedRequester",
+      JSON.stringify({ id: 2, name: "Weerapong Chaiyaporn" })
+    );
+    return render(
+      <BrowserRouter>
+        <RequesterProvider>
+          <MyTickets />
+        </RequesterProvider>
+      </BrowserRouter>
+    );
+  };
+
+  it("renders desktop table rows and mobile cards with ticket data", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("ticket-row")).toHaveLength(2);
+    });
+    expect(screen.getAllByTestId("ticket-card")).toHaveLength(2);
+    expect(screen.getAllByText("VPN drops every 5 minutes").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("TK-20260906-0001").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("passes the selected requester id as the ownership scope", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(getTicketsMock).toHaveBeenCalled();
+    });
+    const [, requesterId] = getTicketsMock.mock.calls[getTicketsMock.mock.calls.length - 1];
+    expect(requesterId).toBe(2);
+  });
+
+  it("shows the empty state when there are no tickets and no filters", async () => {
+    getTicketsMock.mockResolvedValue({
+      tickets: [],
+      pagination: { total: 0, page: 1, limit: 10, totalPages: 1 },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeDefined();
+    });
+    expect(screen.queryByTestId("no-results")).toBeNull();
+  });
+
+  it("shows the no-results state with Clear Filters when a search matches nothing", async () => {
+    getTicketsMock.mockResolvedValue({
+      tickets: [],
+      pagination: { total: 0, page: 1, limit: 10, totalPages: 1 },
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ticket-search")).toBeDefined();
+    });
+
+    fireEvent.change(screen.getByTestId("ticket-search"), { target: { value: "zzzz" } });
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("no-results")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("empty-state")).toBeDefined();
+    });
+  });
+
+  it("sends search and filter parameters to the API", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(getTicketsMock).toHaveBeenCalled();
+    });
+
+    fireEvent.change(screen.getByTestId("ticket-search"), { target: { value: "VPN" } });
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }));
+
+    fireEvent.change(screen.getByTestId("filter-status"), { target: { value: "PENDING" } });
+
+    await waitFor(() => {
+      const last = getTicketsMock.mock.calls[getTicketsMock.mock.calls.length - 1];
+      expect(last[0]).toEqual(expect.objectContaining({ search: "VPN", status: "PENDING" }));
+    });
+  });
+
+  it("sorts by priority when the sort control is activated", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(getTicketsMock).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByTestId("sort-priority"));
+
+    await waitFor(() => {
+      const last = getTicketsMock.mock.calls[getTicketsMock.mock.calls.length - 1];
+      expect(last[0]).toEqual(expect.objectContaining({ sort: "priority", order: "desc" }));
+    });
+  });
+
+  it("paginates: clicking page 2 refetches with page=2", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("page-number")).toHaveLength(3);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    await waitFor(() => {
+      const last = getTicketsMock.mock.calls[getTicketsMock.mock.calls.length - 1];
+      expect(last[0]).toEqual(expect.objectContaining({ page: 2 }));
+    });
+  });
+
+  it("shows an error state with a Retry that refetches", async () => {
+    getTicketsMock.mockRejectedValue(new Error("boom"));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tickets-error")).toBeDefined();
+    });
+
+    getTicketsMock.mockResolvedValue({ tickets: TICKETS, pagination: PAGINATION });
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("ticket-row")).toHaveLength(2);
+    });
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -1,8 +1,10 @@
 # Lab 2 – Test Plan and Evidence
 
-All test files live under `server/tests/lab-02/` and `client/tests/lab-02/` (E2E: `client/tests/lab-02/flow.spec.ts`).
+All test files live under `server/tests/` and `client/tests/lab-02/` (E2E: `client/tests/lab-02/flow.spec.ts`).
 
 Per labsheet §9.2, planned coverage spans all six required levels: **Unit, API, UI (component), UI Style, Responsive, and E2E**. Every AC in `specification.md` §9 (AC-01–AC-26) maps to at least one test below; see §2 for the AC → Test traceability matrix.
+
+**Current status (light = fully done):** server **6 files / 21 tests pass**, client **6 files / 33 tests pass** — API suite covers Health, Categories, Systems, Requesters, Create Ticket (POST), and My Tickets (GET); UI suite covers header/forms/requester selection, Create Ticket, and My Tickets screens. Unit, Perf, and E2E rows below remain `Planned`.
 
 ---
 
@@ -20,8 +22,8 @@ Per labsheet §9.2, planned coverage spans all six required levels: **Unit, API,
 | 8 | API | Issue 52 | AC-01 | Supertest/Vitest | `tickets.test.ts` — POST creates ticket, returns ticketNo | Pass |
 | 9 | API | Issue 52 | AC-17 | Supertest/Vitest | `tickets.test.ts` — 3 same-day tickets, sequential nos | Planned |
 | 10 | API | Issue 52 | AC-02 | Supertest/Vitest | `tickets.test.ts` — title/description length → 400 | Pass |
-| 11 | API | Issue 56 | AC-13 | Supertest/Vitest | `tickets.test.ts` — default sort `createdAt desc` | Planned |
-| 12 | API | Issue 56 | AC-14 | Supertest/Vitest | `tickets.test.ts` — invalid sort/page/limit → 400 | Planned |
+| 11 | API | Issue 56 | AC-13 | Supertest/Vitest | `tickets-list.test.ts` — default sort `createdAt desc` | Planned |
+| 12 | API | Issue 56 | AC-14 | Supertest/Vitest | `tickets-list.test.ts` — invalid sort/page/limit → 400 | Pass |
 | 13 | API | Issue 60 | AC-20 | Supertest/Vitest | `attachments.test.ts` — file >5MB → 413 | Planned |
 | 14 | API | Issue 60 | AC-20 | Supertest/Vitest | `attachments.test.ts` — bad MIME type → 415 | Planned |
 | 15 | API | Issue 60 | AC-19 | Supertest/Vitest | `attachments.test.ts` — 6th active attachment → 400 | Planned |
@@ -31,28 +33,40 @@ Per labsheet §9.2, planned coverage spans all six required levels: **Unit, API,
 | 19 | API | Issue 60 | AC-22 | Supertest/Vitest | `attachments.test.ts` — soft-remove sets isRemoved+reason | Planned |
 | 20 | API | Issue 60 | AC-23 | Supertest/Vitest | `attachments.test.ts` — download removed file → 410 | Planned |
 | 21 | API | Issue 60 | AC-24 | Supertest/Vitest | `attachments.test.ts` — non-owner action → 403 | Planned |
-| 22 | API | Issue 59 | AC-10 | Supertest/Vitest | `tickets.test.ts` — cross-requester GET → 403/404 | Planned |
+| 22 | API | Issue 55 | AC-10 | Supertest/Vitest | `tickets-list.test.ts` — cross-requester GET → own-list only / 403 | Pass |
 | 23 | UI | Issue 49, 51 | AC-06 | Vitest/RTL | `Header.test.tsx` — Simulation-Mode banner shows | Planned |
-| 24 | UI | Issue 49, 50 | AC-08 | Vitest/RTL | `RequesterSelection.test.tsx` — renders + selects requester | Planned |
-| 25 | UI | Issue 50 | AC-09 | Vitest/RTL | `RequesterSelection.test.tsx` — persists via localStorage | Planned |
+| 24 | UI | Issue 49, 50 | AC-08 | Vitest/RTL | `RequesterSelection.test.tsx` — renders + selects requester | Pass |
+| 25 | UI | Issue 50 | AC-09 | Vitest/RTL | `RequesterSelection.test.tsx` — persists via localStorage | Pass |
 | 26 | UI | Issue 48, 49 | — | Vitest/RTL | `RequesterSelection.test.tsx` — loading/empty/error states | Planned |
-| 27 | UI | Issue 53, 54 | AC-02 | Vitest/RTL | `CreateTicket.test.tsx` — inline error below field | Planned |
-| 28 | UI | Issue 55 | AC-03 | Vitest/RTL | `CreateTicket.test.tsx` — busy state, no double-submit | Planned |
+| 27 | UI | Issue 53, 54 | AC-02 | Vitest/RTL | `CreateTicket.test.tsx` — inline error below field | Pass |
+| 28 | UI | Issue 55 | AC-03 | Vitest/RTL | `CreateTicket.test.tsx` — busy state, no double-submit | Pass |
 | 29 | UI | Issue 53, 55 | AC-04 | Vitest/RTL | `CreateTicket.test.tsx` — API failure preserves fields | Planned |
 | 30 | UI | Issue 62 | AC-05 | Vitest/RTL | `CreateTicket.test.tsx` — invalid file rejected pre-submit | Planned |
 | 31 | UI | Issue 55 | AC-01 | Vitest/RTL | `CreateTicket.test.tsx` — success shows ticket number | Planned |
-| 32 | UI | Issue 58 | AC-11, AC-12 | Vitest/RTL | `MyTickets.test.tsx` — search/filter query params | Planned |
-| 33 | UI | Issue 57 | AC-15 | Vitest/RTL | `MyTickets.test.tsx` — empty vs. no-results states | Planned |
+| 32 | UI | Issue 58 | AC-11, AC-12 | Vitest/RTL | `MyTickets.test.tsx` — search/filter query params | Pass |
+| 33 | UI | Issue 57 | AC-15 | Vitest/RTL | `MyTickets.test.tsx` — empty vs. no-results states | Pass |
 | 34 | UI | Issue 58 | AC-26 | Vitest/RTL | `MyTickets.test.tsx` — keyboard-operable controls | Planned |
 | 35 | UI | Issue 61 | AC-16 | Vitest/RTL | `RequesterTicketDetail.test.tsx` — read-only + badges | Planned |
 | 36 | UI Style | Issue 47, 53, 61 | — | Vitest/RTL (CSS) | `uiStyle.test.tsx` — read-only tokens, asterisks, badge text | Planned |
 | 37 | UI Style | Issue 65 | — | Playwright | `flow.spec.ts` (style pass) — Zen Green tokens render | Planned |
-| 38 | Responsive | Issue 57 | AC-25 | Vitest/RTL | `MyTickets.test.tsx` — table (desktop) vs. cards (mobile) | Planned |
+| 38 | Responsive | Issue 57 | AC-25 | Vitest/RTL | `MyTickets.test.tsx` — table (desktop) vs. cards (mobile) | Pass |
 | 39 | Responsive | Issue 65 | AC-25 | Playwright | `flow.spec.ts` — desktop/tablet/mobile screenshots | Planned |
 | 40 | E2E | Issue 64 | AC-18 | Playwright | `flow.spec.ts` — full select→create→list flow | Planned |
 | 41 | API | Issue 52 | — | Supertest/Vitest | `tickets.test.ts` — non-numeric header → 401 | Pass |
 | 42 | API | Issue 52 | — | Supertest/Vitest | `tickets.test.ts` — bad categoryId/systemId → 400 | Pass |
 | 43 | API | Issue 52 | — | Supertest/Vitest | `tickets.test.ts` — inactive requester create → 403 | Pass |
+| 44 | API | Issue 55 | AC-10 | Supertest/Vitest | `tickets-list.test.ts` — GET is scoped to active requester (401/403) | Pass |
+| 45 | API | Issue 55 | — | Supertest/Vitest | `tickets-list.test.ts` — stable shape incl. category + system | Pass |
+| 46 | API | Issue 55 | AC-14 | Supertest/Vitest | `tickets-list.test.ts` — pagination `limit`+`page`+`totalPages` | Pass |
+| 47 | API | Issue 55 | AC-11 | Supertest/Vitest | `tickets-list.test.ts` — case-insensitive search title/description | Pass |
+| 48 | API | Issue 55 | AC-12 | Supertest/Vitest | `tickets-list.test.ts` — filter status + priority | Pass |
+| 49 | API | Issue 56 | AC-13 | Supertest/Vitest | `tickets-list.test.ts` — sort priority asc/desc | Pass |
+| 50 | UI | Issue 55 | AC-10 | Vitest/RTL | `MyTickets.test.tsx` — passes active requester id as ownership scope | Pass |
+| 51 | UI | Issue 56 | AC-13 | Vitest/RTL | `MyTickets.test.tsx` — sort control activates priority sort | Pass |
+| 52 | UI | Issue 58 | AC-14 | Vitest/RTL | `MyTickets.test.tsx` — pagination: page 2 refetch | Pass |
+| 53 | UI | Issue 55 | — | Vitest/RTL | `MyTickets.test.tsx` — error state + Retry refetch | Pass |
+| 54 | UI | Issue 53 | — | Vitest/RTL | `CreateTicket.test.tsx` — dropdowns load categories + systems | Pass |
+| 55 | API | Issue 43 | — | Supertest/Vitest | `systems.test.ts` — GET /api/systems seeded names in id order | Pass |
 
 ---
 
@@ -69,11 +83,11 @@ Per labsheet §9.2, planned coverage spans all six required levels: **Unit, API,
 | AC-07 | 5, 6 |
 | AC-08 | 24 |
 | AC-09 | 25 |
-| AC-10 | 22 |
-| AC-11 | 32 |
-| AC-12 | 32 |
-| AC-13 | 11 |
-| AC-14 | 12 |
+| AC-10 | 22, 44, 50 |
+| AC-11 | 32, 47 |
+| AC-12 | 32, 48 |
+| AC-13 | 11, 49, 51 |
+| AC-14 | 12, 46, 52 |
 | AC-15 | 33 |
 | AC-16 | 35 |
 | AC-17 | 9 |
@@ -87,59 +101,121 @@ Per labsheet §9.2, planned coverage spans all six required levels: **Unit, API,
 | AC-25 | 38, 39 |
 | AC-26 | 34 |
 
-Rows 1–4, 17, 26, 36–37, 39, 41–43 are traced to labsheet requirements or specific BRs rather than a single numbered AC, since they verify preconditions, cross-cutting rules, or a required test *level* rather than one user-observable outcome.
+Rows 1–4, 17, 26, 36–37, 39, 41–42, 45, 53–55 are traced to labsheet requirements or specific BRs rather than a single numbered AC, since they verify preconditions, cross-cutting rules, or a required test *level* rather than one user-observable outcome.
 
 ---
 
 ## 3. Evidence
 
-Paste your passing terminal output / screenshot below, one section per Issue as it's completed:
+Paste your passing terminal output / screenshot below, one section per Issue as it's completed. Current full run (both suites green):
 
-### Issue 43: Create and seed IT request categories
-**Test File:** `server/tests/lab-02/categories.test.ts`
-
+### Server suite — full run
 ```text
-$ pnpm test
-$ vitest run
+$ vitest run   # cd server
 
- ✓ tests/categories.test.ts (1)
-   ✓ GET /api/categories (1)
-     ✓ returns HTTP 200 and all seeded categories in predictable id order
+ ✓ tests/health.test.ts (1 test)
+ ✓ tests/categories.test.ts (1 test)
+ ✓ tests/systems.test.ts (1 test)
+ ✓ tests/requesters.test.ts (2 tests)
+ ✓ tests/tickets.test.ts (7 tests)
+ ✓ tests/tickets-list.test.ts (9 tests)
 
-Test Files  1 passed (1)
-     Tests  1 passed (1)
+ Test Files  6 passed (6)
+      Tests 21 passed (21)
 ```
 
+### Client suite — full run
+```text
+$ vitest run   # cd client
 
-### Issue 48: Implement a GET API endpoint to fetch only active Development Requesters
-**Test File:** `server/tests/lab-02/requesters.test.ts`
+ ✓ tests/lab-02/Badge.test.tsx (3 tests)
+ ✓ tests/lab-02/FormComponents.test.tsx (14 tests)
+ ✓ tests/lab-02/RequesterSelection.test.tsx (2 tests)
+ ✓ tests/lab-02/CreateTicket.test.tsx (3 tests)
+ ✓ tests/lab-02/MyTickets.test.tsx (8 tests)
+ ✓ tests/lab-01/App.test.tsx (3 tests)
+
+ Test Files  6 passed (6)
+      Tests 33 passed (33)
+```
+
+### Issue 43: Create and seed IT request categories
+**Test File:** `server/tests/categories.test.ts`
 
 ```text
-$ pnpm test
-$ vitest run
+ ✓ tests/categories.test.ts (1)
+   ✓ returns HTTP 200 and all seeded categories in predictable id order
+```
 
- ✓ tests/requesters.test.ts (4)
-   ✓ GET /api/requesters (4)
-     ✓ returns HTTP 200 with only active requesters, shaped { id, name }
-     ✓ returns requesters in ascending alphabetical order by name
-     ✓ returns exactly the 4 active seeded requesters by name, in alphabetical order
-     ✓ excludes the seeded inactive requester
+### Issue 43: Related System list
+**Test File:** `server/tests/systems.test.ts`
 
-Test Files  1 passed (1)
-     Tests  4 passed (4)
+```text
+ ✓ tests/systems.test.ts (1)
+   ✓ GET /api/systems returns HTTP 200 with seeded systems in id order
+```
+
+### Issue 48: Implement a GET API endpoint to fetch only active Development Requesters
+**Test File:** `server/tests/requesters.test.ts`
+
+```text
+ ✓ tests/requesters.test.ts (2)
+   ✓ returns HTTP 200 with only active requesters
+   ✓ excludes the seeded inactive requester
 ```
 
 ### Issue 52: Implement a POST API endpoint to save tickets and automatically generate an official Ticket Number
 **Test File:** `server/tests/tickets.test.ts`
 
 ```text
-$pnpm test$ vitest run
-
- ✓ tests/categories.test.ts (1)
- ✓ tests/health.test.ts (1)
  ✓ tests/tickets.test.ts (7)
+   ✓ should create a ticket and return 201 with generated ticketNo
+   ✓ should return 401 Unauthorized when x-requester-id header is missing
+   ✓ should return 401 Unauthorized when x-requester-id is not a valid integer
+   ✓ should return 400 Bad Request when required fields are invalid/missing
+   ✓ should return 400 Bad Request when categoryId does not reference an existing Category
+   ✓ should return 400 Bad Request when systemId does not reference an existing Related System
+   ✓ should return 403 Forbidden when the Requester is inactive
+```
 
-Test Files  3 passed (3)
-     Tests  9 passed (9)
+### Issue 55: My Tickets — GET /api/tickets (ownership, search, filter, sort, pagination)
+**Test File:** `server/tests/tickets-list.test.ts`
+
+```text
+ ✓ tests/tickets-list.test.ts (9)
+   ✓ returns HTTP 401 when the x-requester-id header is missing
+   ✓ returns HTTP 403 for an inactive or unknown requester
+   ✓ owns the list: requester A sees only their tickets
+   ✓ returns a stable response shape including category and system
+   ✓ paginates: limit + page + totalPages
+   ✓ searches case-insensitively on title and description
+   ✓ filters by status and priority
+   ✓ sorts by priority descending (heaviest first) and ascending
+   ✓ rejects invalid sort, page, and limit with HTTP 400
+```
+
+### Issue 55: My Tickets screen (UI)
+**Test File:** `client/tests/lab-02/MyTickets.test.tsx`
+
+```text
+ ✓ tests/lab-02/MyTickets.test.tsx (8)
+   ✓ renders desktop table rows and mobile cards with ticket data
+   ✓ passes the selected requester id as the ownership scope
+   ✓ shows the empty state when there are no tickets and no filters
+   ✓ shows the no-results state with Clear Filters when a search matches nothing
+   ✓ sends search and filter parameters to the API
+   ✓ sorts by priority when the sort control is activated
+   ✓ paginates: clicking page 2 refetches with page=2
+   ✓ shows an error state with a Retry that refetches
+```
+
+### Issue 52: Create Ticket screen (UI)
+**Test File:** `client/tests/lab-02/CreateTicket.test.tsx`
+
+```text
+ ✓ tests/lab-02/CreateTicket.test.tsx (3)
+   ✓ dynamically loads Categories and Related Systems into dropdowns
+   ✓ shows field validation errors with red asterisks when submitting empty form
+   ✓ shows a busy state on the Submit button during API processing
 ```
 

--- a/server/controllers/listTickets.controller.ts
+++ b/server/controllers/listTickets.controller.ts
@@ -17,9 +17,9 @@ const listQuerySchema = z.object({
 
 function requesterIdFromHeader(req: Request): number | null {
   const raw = req.headers['x-requester-id'];
-  if (!raw) return null;
-  const id = parseInt(raw as string, 10);
-  return Number.isNaN(id) ? null : id;
+  if (typeof raw !== 'string' || !/^\d+$/.test(raw)) return null;
+  const id = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
 }
 
 export const listTickets = async (req: Request, res: Response) => {

--- a/server/controllers/listTickets.controller.ts
+++ b/server/controllers/listTickets.controller.ts
@@ -1,0 +1,108 @@
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import { getPrisma } from '../src/prisma.js';
+
+const listQuerySchema = z.object({
+  search: z.string().trim().max(100).optional(),
+  categoryId: z.coerce.number().int().positive().optional(),
+  systemId: z.coerce.number().int().positive().optional(),
+  status: z.enum(['PENDING', 'IN_PROGRESS', 'RESOLVED', 'CLOSED']).optional(),
+  priority: z.enum(['LOW', 'MEDIUM', 'HIGH', 'URGENT']).optional(),
+  sort: z.enum(['createdAt', 'priority']).default('createdAt'),
+  order: z.enum(['asc', 'desc']).default('desc'),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
+function requesterIdFromHeader(req: Request): number | null {
+  const raw = req.headers['x-requester-id'];
+  if (!raw) return null;
+  const id = parseInt(raw as string, 10);
+  return Number.isNaN(id) ? null : id;
+}
+
+export const listTickets = async (req: Request, res: Response) => {
+  try {
+    const requesterId = requesterIdFromHeader(req);
+    if (requesterId === null) {
+      return res.status(401).json({
+        error: { code: 'UNAUTHORIZED', message: 'Missing or invalid x-requester-id header' },
+      });
+    }
+
+    const prisma = getPrisma();
+
+    const requester = await prisma.requester.findUnique({ where: { id: requesterId } });
+    if (!requester || !requester.isActive) {
+      return res.status(403).json({
+        error: { code: 'FORBIDDEN', message: 'Requester is inactive or does not exist' },
+      });
+    }
+
+    const query = listQuerySchema.parse(req.query);
+
+    const where: Prisma.TicketWhereInput = {
+      requesterId,
+      ...(query.search
+        ? {
+            OR: [
+              { title: { contains: query.search, mode: 'insensitive' } },
+              { description: { contains: query.search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+      ...(query.categoryId ? { categoryId: query.categoryId } : {}),
+      ...(query.systemId ? { systemId: query.systemId } : {}),
+      ...(query.status ? { status: query.status } : {}),
+      ...(query.priority ? { priority: query.priority } : {}),
+    };
+    const orderBy =
+      query.sort === 'priority'
+        ? { priority: query.order }
+        : { createdAt: query.order };
+
+    const skip = (query.page - 1) * query.limit;
+
+    const [tickets, total] = await prisma.$transaction([
+      prisma.ticket.findMany({
+        where,
+        orderBy,
+        skip,
+        take: query.limit,
+        select: {
+          id: true,
+          ticketNo: true,
+          title: true,
+          description: true,
+          priority: true,
+          status: true,
+          createdAt: true,
+          category: { select: { id: true, name: true } },
+          system: { select: { id: true, name: true } },
+        },
+      }),
+      prisma.ticket.count({ where }),
+    ]);
+
+    return res.json({
+      tickets,
+      pagination: {
+        total,
+        page: query.page,
+        limit: query.limit,
+        totalPages: Math.max(1, Math.ceil(total / query.limit)),
+      },
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const message = error.issues?.[0]?.message || 'Validation error';
+      return res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message },
+      });
+    }
+    return res.status(500).json({
+      error: { code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' },
+    });
+  }
+};

--- a/server/src/App.ts
+++ b/server/src/App.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
 import { createTicket } from "../controllers/ticket.controller.js";
+import { listTickets } from "../controllers/listTickets.controller.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -67,7 +68,8 @@ app.get("/api/requesters", async (_req: Request, res: Response) => {
 // Issue 43 — Related System list
 // GET /api/systems
 // Response shape per api-spec.md §3: [{ id, name }]. Ordered by id since this
-// feeds a user-facing Related System dropdown on Create Ticket.
+// feeds a user-facing Related System dropdown on Create Ticket (and the
+// My Tickets filter dropdown).
 app.get("/api/systems", async (_req: Request, res: Response) => {
   try {
     const prisma = getPrisma();
@@ -85,6 +87,11 @@ app.get("/api/systems", async (_req: Request, res: Response) => {
     res.status(500).json({ error: "Failed to fetch related systems" });
   }
 });
+
+// Issue 55 — My Tickets list
+// GET /api/tickets
+// Paginated, searchable, filterable, sortable list owned by the active Requester.
+app.get("/api/tickets", listTickets);
 
 // Issue 52 — Create Ticket
 // POST /api/tickets

--- a/server/tests/tickets-list.test.ts
+++ b/server/tests/tickets-list.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { app } from "../src/App.js";
+import { getPrisma } from "../src/prisma.js";
+
+const prisma = getPrisma();
+
+const REQ_A_EMAIL = "list-test-a@toktikit.com";
+const REQ_B_EMAIL = "list-test-b@toktikit.com";
+
+let requesterA: { id: number };
+let requesterB: { id: number };
+let testCategoryId: number;
+let testSystemId: number;
+let ticketIds: number[] = [];
+
+let ticketNoSeq = 1;
+function makeTicketNo(): string {
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  return `TK-${date}-${String(ticketNoSeq++).padStart(4, "0")}`;
+}
+
+describe("GET /api/tickets", () => {
+  beforeAll(async () => {
+    const category = await prisma.category.findFirst({ orderBy: { id: "asc" } });
+    const system = await prisma.relatedSystem.findFirst({ orderBy: { id: "asc" } });
+    testCategoryId = category!.id;
+    testSystemId = system!.id;
+
+    requesterA = await prisma.requester.create({
+      data: { name: "List Test A", email: REQ_A_EMAIL, isActive: true },
+    });
+    requesterB = await prisma.requester.create({
+      data: { name: "List Test B", email: REQ_B_EMAIL, isActive: true },
+    });
+
+    const rows = await prisma.$transaction(
+      [
+        { title: "Alpha Login Failure", description: "Cannot sign in to the portal", priority: "HIGH", status: "PENDING" },
+        { title: "Beta Printer Jam", description: "Printer jams on the third floor", priority: "LOW", status: "IN_PROGRESS" },
+        { title: "Gamma VPN Dropping", description: "VPN drops every five minutes", priority: "URGENT", status: "RESOLVED" },
+      ].map((r) =>
+        prisma.ticket.create({
+          data: {
+            ticketNo: makeTicketNo(),
+            title: r.title,
+            description: r.description,
+            priority: r.priority,
+            status: r.status,
+            requesterId: requesterA.id,
+            categoryId: testCategoryId,
+            systemId: testSystemId,
+          },
+        })
+      )
+    );
+    ticketIds = rows.map((t) => t.id);
+
+    await prisma.ticket.create({
+      data: {
+        ticketNo: makeTicketNo(),
+        title: "B Ticket Never Shown",
+        description: "This ticket belongs to requester B only",
+        priority: "MEDIUM",
+        status: "PENDING",
+        requesterId: requesterB.id,
+        categoryId: testCategoryId,
+        systemId: testSystemId,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.ticket.deleteMany({ where: { id: { in: ticketIds } } });
+    await prisma.ticket.deleteMany({ where: { requesterId: requesterB.id } });
+    await prisma.requester.deleteMany({ where: { email: { in: [REQ_A_EMAIL, REQ_B_EMAIL] } } });
+  });
+
+  it("returns HTTP 401 when the x-requester-id header is missing", async () => {
+    const res = await request(app).get("/api/tickets");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns HTTP 403 for an inactive or unknown requester", async () => {
+    const res = await request(app)
+      .get("/api/tickets")
+      .set("x-requester-id", "999999");
+    expect(res.status).toBe(403);
+  });
+
+  it("owns the list: requester A sees only their tickets", async () => {
+    const res = await request(app)
+      .get("/api/tickets")
+      .set("x-requester-id", String(requesterA.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.tickets).toHaveLength(3);
+    const titles = res.body.tickets.map((t: { title: string }) => t.title);
+    expect(titles).toContain("Alpha Login Failure");
+    expect(titles).not.toContain("B Ticket Never Shown");
+    expect(res.body.pagination.total).toBe(3);
+  });
+
+  it("returns a stable response shape including category and system", async () => {
+    const res = await request(app)
+      .get("/api/tickets")
+      .set("x-requester-id", String(requesterA.id));
+
+    const ticket = res.body.tickets[0];
+    expect(Object.keys(ticket).sort()).toEqual(
+      ["category", "createdAt", "description", "id", "priority", "status", "system", "ticketNo", "title"].sort()
+    );
+    expect(typeof ticket.category.id).toBe("number");
+    expect(typeof ticket.category.name).toBe("string");
+    expect(typeof ticket.system.id).toBe("number");
+    expect(typeof ticket.system.name).toBe("string");
+  });
+
+  it("paginates: limit + page + totalPages", async () => {
+    const res = await request(app)
+      .get("/api/tickets?limit=2&page=2")
+      .set("x-requester-id", String(requesterA.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.tickets).toHaveLength(1);
+    expect(res.body.pagination).toEqual({
+      total: 3,
+      page: 2,
+      limit: 2,
+      totalPages: 2,
+    });
+  });
+
+  it("searches case-insensitively on title and description", async () => {
+    const res = await request(app)
+      .get("/api/tickets?search=VPN")
+      .set("x-requester-id", String(requesterA.id));
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.total).toBe(1);
+    expect(res.body.tickets[0].title).toBe("Gamma VPN Dropping");
+
+    const resLower = await request(app)
+      .get("/api/tickets?search=vpn")
+      .set("x-requester-id", String(requesterA.id));
+    expect(resLower.body.pagination.total).toBe(1);
+  });
+
+  it("filters by status and priority", async () => {
+    const statusRes = await request(app)
+      .get("/api/tickets?status=RESOLVED")
+      .set("x-requester-id", String(requesterA.id));
+    expect(statusRes.status).toBe(200);
+    expect(statusRes.body.pagination.total).toBe(1);
+    expect(statusRes.body.tickets[0].title).toBe("Gamma VPN Dropping");
+
+    const priorityRes = await request(app)
+      .get("/api/tickets?priority=HIGH")
+      .set("x-requester-id", String(requesterA.id));
+    expect(priorityRes.body.pagination.total).toBe(1);
+    expect(priorityRes.body.tickets[0].title).toBe("Alpha Login Failure");
+  });
+
+  it("sorts by priority descending (heaviest first) and ascending", async () => {
+    const resDesc = await request(app)
+      .get("/api/tickets?sort=priority&order=desc")
+      .set("x-requester-id", String(requesterA.id));
+
+    expect(resDesc.status).toBe(200);
+    const descPriorities = resDesc.body.tickets.map((t: { priority: string }) => t.priority);
+    // Postgres enum definition order: LOW < MEDIUM < HIGH < URGENT (heaviness).
+    expect(descPriorities).toEqual(["URGENT", "HIGH", "LOW"]);
+
+    const resAsc = await request(app)
+      .get("/api/tickets?sort=priority&order=asc")
+      .set("x-requester-id", String(requesterA.id));
+    const ascPriorities = resAsc.body.tickets.map((t: { priority: string }) => t.priority);
+    expect(ascPriorities).toEqual(["LOW", "HIGH", "URGENT"]);
+  });
+
+  it("rejects invalid sort, page, and limit with HTTP 400", async () => {
+    const badSort = await request(app)
+      .get("/api/tickets?sort=unknown")
+      .set("x-requester-id", String(requesterA.id));
+    expect(badSort.status).toBe(400);
+
+    const badPage = await request(app)
+      .get("/api/tickets?page=abc")
+      .set("x-requester-id", String(requesterA.id));
+    expect(badPage.status).toBe(400);
+
+    const badLimit = await request(app)
+      .get("/api/tickets?limit=999")
+      .set("x-requester-id", String(requesterA.id));
+    expect(badLimit.status).toBe(400);
+  });
+});

--- a/server/tests/tickets-list.test.ts
+++ b/server/tests/tickets-list.test.ts
@@ -81,6 +81,15 @@ describe("GET /api/tickets", () => {
     expect(res.status).toBe(401);
   });
 
+  it("returns HTTP 401 for numeric-yet-invalid headers (permissive parseInt bypass)", async () => {
+    for (const bad of ["12abc", "1.5", "abc", "", "0", "-5"]) {
+      const res = await request(app)
+        .get("/api/tickets")
+        .set("x-requester-id", bad as string);
+      expect(res.status).toBe(401);
+    }
+  });
+
   it("returns HTTP 403 for an inactive or unknown requester", async () => {
     const res = await request(app)
       .get("/api/tickets")


### PR DESCRIPTION
## Summary
Full-stack implementation of the **My Tickets** screen (Issue 55/56/57/58 scope):
- Active Requester can view only their own tickets
- Desktop table / mobile cards layout
- Search, filter (category/system/status/priority), sort (createdAt/priority), pagination
- Empty state vs. no-results state
- Cross-requester refetch when the active Requester changes

## Backend (GET /api/tickets)
- Ownership enforced via `x-requester-id` (401 missing/invalid, 403 inactive)
- Query params: `search`, `categoryId`, `systemId`, `status`, `priority`, `sort`, `order`, `page`, `limit`
- Pagination metadata `{ total, page, limit, totalPages }`
- Controller: `server/controllers/listTickets.controller.ts`
- Tests: `server/tests/tickets-list.test.ts` (9)

## Frontend
- `client/src/pages/MyTickets.tsx` with desktop table + mobile cards + pagination bar + empty/no-results/error states
- `client/src/api.ts` extended with `getTickets()` + query builder
- Route `/my-tickets` wired behind `ProtectedRoute`
- Tests: `client/tests/lab-02/MyTickets.test.tsx` (8)

## Rebase note
Rebased onto latest `lab2-staging` (includes merged Issue 9 Create Ticket). Resolved duplicate `GET /api/systems` and `api.ts` conflicts; removed now-unused `ComingSoon`.

## Docs
`docs/lab-02/tests.md` updated: server suite 6 files / 21 tests, client suite 6 files / 33 tests.

## Verification
- Server: build OK, `npm test` 21/21
- Client: lint OK, `npm test` 33/33, build OK